### PR TITLE
Add API for working with users that are currently offline

### DIFF
--- a/src/api/java/de/fearnixx/jeak/service/teamspeak/IUserService.java
+++ b/src/api/java/de/fearnixx/jeak/service/teamspeak/IUserService.java
@@ -1,0 +1,39 @@
+package de.fearnixx.jeak.service.teamspeak;
+
+import de.fearnixx.jeak.teamspeak.data.IClient;
+import de.fearnixx.jeak.teamspeak.data.IUser;
+
+import java.util.List;
+
+/**
+ * Service to provide access to online (client) and offline (user) instances for plugins to work with.
+ * <p>
+ * Note the following:
+ * As TS3 does not enforce uniqueness, developers need to be aware of this multi-result scenario.
+ * In fact, TS3 has been observed to end up with multiple entries of the same "unique" id in the database.
+ * In addition, as {@link IClient} extends {@link IUser} the DBID-searching methods can also return multiple instances for each connection a client has.
+ * This is why all search methods return lists.
+ * </p>
+ */
+public interface IUserService {
+
+    /**
+     * Searches a user based on their unique ID.
+     * @apiNote please note the class-level javadoc.
+     */
+    List<IUser> findUserByUniqueID(String ts3uniqueID);
+
+    /**
+     * Searches a user based on their database ID.
+     * @apiNote please note the class-level javadoc.
+     */
+    List<IUser> findUserByDBID(int ts3dbID);
+
+    List<IUser> findUserByNickname(String ts3nickname);
+
+    List<IClient> findClientByUniqueID(String ts3uniqueID);
+
+    List<IClient> findClientByDBID(int ts3dbID);
+
+    List<IClient> findClientByNickname(String ts3nickname);
+}

--- a/src/api/java/de/fearnixx/jeak/service/teamspeak/IUserService.java
+++ b/src/api/java/de/fearnixx/jeak/service/teamspeak/IUserService.java
@@ -29,11 +29,27 @@ public interface IUserService {
      */
     List<IUser> findUserByDBID(int ts3dbID);
 
+    /**
+     * Searches a user based on their nickname.
+     * @apiNote please note the class-level javadoc.
+     */
     List<IUser> findUserByNickname(String ts3nickname);
 
+    /**
+     * Searches a client based on their unique ID.
+     * @apiNote please note the class-level javadoc.
+     */
     List<IClient> findClientByUniqueID(String ts3uniqueID);
 
+    /**
+     * Searches a client based on their database ID.
+     * @apiNote please note the class-level javadoc.
+     */
     List<IClient> findClientByDBID(int ts3dbID);
 
+    /**
+     * Searches a client based on their nickname.
+     * @apiNote please note the class-level javadoc.
+     */
     List<IClient> findClientByNickname(String ts3nickname);
 }

--- a/src/api/java/de/fearnixx/jeak/service/teamspeak/IUserService.java
+++ b/src/api/java/de/fearnixx/jeak/service/teamspeak/IUserService.java
@@ -14,6 +14,10 @@ import java.util.List;
  * In addition, as {@link IClient} extends {@link IUser} the DBID-searching methods can also return multiple instances for each connection a client has.
  * This is why all search methods return lists.
  * </p>
+ * <p>
+ * For any operations returning offline representations, online representations {@link IClient} may be returned.
+ * This is due to {@link IUser} being a super interface of {@link IClient}.
+ * </p>
  */
 public interface IUserService {
 

--- a/src/api/java/de/fearnixx/jeak/service/teamspeak/IUserService.java
+++ b/src/api/java/de/fearnixx/jeak/service/teamspeak/IUserService.java
@@ -4,6 +4,7 @@ import de.fearnixx.jeak.teamspeak.data.IClient;
 import de.fearnixx.jeak.teamspeak.data.IUser;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Service to provide access to online (client) and offline (user) instances for plugins to work with.
@@ -36,6 +37,7 @@ public interface IUserService {
     /**
      * Searches a user based on their nickname.
      * @apiNote please note the class-level javadoc.
+     * @implNote the nickname is searched using case-insensitive "contains".
      */
     List<IUser> findUserByNickname(String ts3nickname);
 
@@ -56,4 +58,10 @@ public interface IUserService {
      * @apiNote please note the class-level javadoc.
      */
     List<IClient> findClientByNickname(String ts3nickname);
+
+    /**
+     * Returns a client by their client ID.
+     * As the client ID is unique for each connection to the TS3 server, this can only be one client, if any.
+     */
+    Optional<IClient> getClientByID(int clientId);
 }

--- a/src/api/java/de/fearnixx/jeak/teamspeak/cache/IDataCache.java
+++ b/src/api/java/de/fearnixx/jeak/teamspeak/cache/IDataCache.java
@@ -1,5 +1,6 @@
 package de.fearnixx.jeak.teamspeak.cache;
 
+import de.fearnixx.jeak.service.teamspeak.IUserService;
 import de.fearnixx.jeak.teamspeak.data.IChannel;
 import de.fearnixx.jeak.teamspeak.data.IClient;
 
@@ -8,7 +9,15 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Cache accessor.
+ * <p>
+ * Access provider to the internal cache for online clients and channels.
+ * Caches are refreshed using the {@code clientlist} and {@code channellist} commands regularly.
+ * See {@link #getChannelRefreshTime()} and ¬{@link #getClientRefreshTime()} for the refresh intervals.
+ * </p>
+ * <p>
+ * This interface and its methods should be used for working with channels and bulk-processing of clients who are currently online.
+ * For getting specific clients or offline representations {@link IUserService} should be used.
+ * </p>
  */
 public interface IDataCache {
 

--- a/src/api/java/de/fearnixx/jeak/teamspeak/data/IClient.java
+++ b/src/api/java/de/fearnixx/jeak/teamspeak/data/IClient.java
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit;
  * <p>
  * Abstract representation of online clients
  */
-public interface IClient extends IDataHolder {
+public interface IClient extends IDataHolder, IUser {
 
     Boolean isValid();
 
@@ -22,29 +22,6 @@ public interface IClient extends IDataHolder {
      * @apiNote This is only valid while the client is online. Refer to {@link #getClientDBID()}
      */
     Integer getClientID();
-
-    /**
-     * @return The database ID of this client
-     */
-    Integer getClientDBID();
-
-    /**
-     * @return The unique client identifier
-     */
-    String getClientUniqueID();
-
-    /**
-     * @return The clients nick name
-     */
-    String getNickName();
-
-    /**
-     * CRC32 checksum of the icon associated with the client.
-     * Empty if none is set.
-     *
-     * @implNote The fix applied to {@link IChannel#}
-     */
-    String getIconID();
 
     enum PlatformType {
         UNKNOWN,
@@ -161,36 +138,11 @@ public interface IClient extends IDataHolder {
     Boolean hasOutputMuted();
 
     /**
-     * IDs for the clients server groups.
-     */
-    List<Integer> getGroupIDs();
-
-    /**
      * For how long the client has been idle.
      *
      * @implNote the value is provided by TeamSpeak.
      */
     Integer getIdleTime();
-
-    /**
-     * The time, the clients uuid has been registered the first time.
-     */
-    Long getCreated();
-
-    /**
-     * Translation of {@link #getCreated()}.
-     */
-    LocalDateTime getCreatedTime();
-
-    /**
-     * The time, the clients uuid has joined the last time.
-     */
-    Long getLastJoin();
-
-    /**
-     * Translation of {@link #getLastJoin()}.
-     */
-    LocalDateTime getLastJoinTime();
 
     /**
      * Returns a {@link IQueryRequest} that can be used to send a message to this client.
@@ -217,23 +169,6 @@ public interface IClient extends IDataHolder {
      * Returns a {@link IQueryRequest} that can be used to move the client to another channel.
      */
     IQueryRequest moveToChannel(Integer channelId);
-
-    /**
-     * Returns a {@link IQueryRequest} that can be used to add the client to server groups.
-     */
-    IQueryRequest addServerGroup(Integer... serverGroupIds);
-
-    /**
-     * Returns a {@link IQueryRequest} that can be used to remove the client from server groups.
-     */
-    IQueryRequest removeServerGroup(Integer... serverGroupIds);
-
-    /**
-     * Returns a {@link IQueryRequest} that can be used to set the clients channel group.
-     *
-     * @apiNote There is no method for "the current channel" as we want plugins to explicitly specify the channel.
-     */
-    IQueryRequest setChannelGroup(Integer channelId, Integer channelGroupId);
 
     /**
      * Returns a {@link IQueryRequest} that can be used to kick the client form the server.

--- a/src/api/java/de/fearnixx/jeak/teamspeak/data/IUser.java
+++ b/src/api/java/de/fearnixx/jeak/teamspeak/data/IUser.java
@@ -29,6 +29,11 @@ public interface IUser {
     String getNickName();
 
     /**
+     * @return The clients custom description.
+     */
+    String getDescription();
+
+    /**
      * CRC32 checksum of the icon associated with the client.
      * Empty if none is set.
      *

--- a/src/api/java/de/fearnixx/jeak/teamspeak/data/IUser.java
+++ b/src/api/java/de/fearnixx/jeak/teamspeak/data/IUser.java
@@ -1,0 +1,90 @@
+package de.fearnixx.jeak.teamspeak.data;
+
+import de.fearnixx.jeak.profile.IProfileService;
+import de.fearnixx.jeak.profile.IUserProfile;
+import de.fearnixx.jeak.teamspeak.query.IQueryRequest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Abstract representation of clients that are offline.
+ * Base interface for all clients.
+ */
+public interface IUser {
+    /**
+     * @return The database ID of this client
+     */
+    Integer getClientDBID();
+
+    /**
+     * @return The unique client identifier
+     */
+    String getClientUniqueID();
+
+    /**
+     * @return The clients nick name
+     */
+    String getNickName();
+
+    /**
+     * CRC32 checksum of the icon associated with the client.
+     * Empty if none is set.
+     *
+     * @implNote The fix applied to {@link IChannel#}
+     */
+    String getIconID();
+
+    /**
+     * IDs for the clients server groups.
+     */
+    List<Integer> getGroupIDs();
+
+    /**
+     * The time, the clients uuid has been registered the first time.
+     */
+    Long getCreated();
+
+    /**
+     * Translation of {@link #getCreated()}.
+     */
+    LocalDateTime getCreatedTime();
+
+    /**
+     * The time, the clients uuid has joined the last time.
+     */
+    Long getLastJoin();
+
+    /**
+     * Translation of {@link #getLastJoin()}.
+     */
+    LocalDateTime getLastJoinTime();
+
+    /**
+     * Returns a {@link IQueryRequest} that can be used to add the client to server groups.
+     */
+    IQueryRequest addServerGroup(Integer... serverGroupIds);
+
+    /**
+     * Returns a {@link IQueryRequest} that can be used to remove the client from server groups.
+     */
+    IQueryRequest removeServerGroup(Integer... serverGroupIds);
+
+    /**
+     * Returns a {@link IQueryRequest} that can be used to set the clients channel group.
+     *
+     * @apiNote There is no method for "the current channel" as we want plugins to explicitly specify the channel.
+     */
+    IQueryRequest setChannelGroup(Integer channelId, Integer channelGroupId);
+
+    /**
+     * Convenience method for {@link IProfileService#getProfile(String)}.
+     */
+    Optional<IUserProfile> getProfile();
+
+    /**
+     * Convenience method for {@link IProfileService#getOrCreateProfile(String)}
+     */
+    IUserProfile getOrCreateProfile();
+}

--- a/src/api/java/de/fearnixx/jeak/teamspeak/data/IUser.java
+++ b/src/api/java/de/fearnixx/jeak/teamspeak/data/IUser.java
@@ -77,14 +77,4 @@ public interface IUser {
      * @apiNote There is no method for "the current channel" as we want plugins to explicitly specify the channel.
      */
     IQueryRequest setChannelGroup(Integer channelId, Integer channelGroupId);
-
-    /**
-     * Convenience method for {@link IProfileService#getProfile(String)}.
-     */
-    Optional<IUserProfile> getProfile();
-
-    /**
-     * Convenience method for {@link IProfileService#getOrCreateProfile(String)}
-     */
-    IUserProfile getOrCreateProfile();
 }

--- a/src/main/java/de/fearnixx/jeak/JeakBot.java
+++ b/src/main/java/de/fearnixx/jeak/JeakBot.java
@@ -16,10 +16,9 @@ import de.fearnixx.jeak.service.locale.LocalizationService;
 import de.fearnixx.jeak.service.mail.MailService;
 import de.fearnixx.jeak.service.notification.NotificationService;
 import de.fearnixx.jeak.service.permission.base.PermissionService;
-import de.fearnixx.jeak.service.permission.teamspeak.QueryPermissionProvider;
 import de.fearnixx.jeak.service.profile.ProfileService;
 import de.fearnixx.jeak.service.task.ITaskService;
-import de.fearnixx.jeak.service.teamspeak.UserService;
+import de.fearnixx.jeak.service.teamspeak.QueryUserService;
 import de.fearnixx.jeak.task.TaskService;
 import de.fearnixx.jeak.teamspeak.IServer;
 import de.fearnixx.jeak.teamspeak.Server;
@@ -170,7 +169,7 @@ public class JeakBot implements Runnable, IBot {
         initializeService(mailSvc);
         initializeService(new ProfileService(new File(confDir, "profiles")));
         initializeService(new PermissionService());
-        initializeService(new UserService());
+        initializeService(new QueryUserService());
 
         // TODO: Remove eagerly loading by a better solution
         dbSvc.onLoad(null);

--- a/src/main/java/de/fearnixx/jeak/JeakBot.java
+++ b/src/main/java/de/fearnixx/jeak/JeakBot.java
@@ -19,6 +19,7 @@ import de.fearnixx.jeak.service.permission.base.PermissionService;
 import de.fearnixx.jeak.service.permission.teamspeak.QueryPermissionProvider;
 import de.fearnixx.jeak.service.profile.ProfileService;
 import de.fearnixx.jeak.service.task.ITaskService;
+import de.fearnixx.jeak.service.teamspeak.UserService;
 import de.fearnixx.jeak.task.TaskService;
 import de.fearnixx.jeak.teamspeak.IServer;
 import de.fearnixx.jeak.teamspeak.Server;
@@ -169,6 +170,7 @@ public class JeakBot implements Runnable, IBot {
         initializeService(mailSvc);
         initializeService(new ProfileService(new File(confDir, "profiles")));
         initializeService(new PermissionService());
+        initializeService(new UserService());
 
         // TODO: Remove eagerly loading by a better solution
         dbSvc.onLoad(null);

--- a/src/main/java/de/fearnixx/jeak/service/permission/base/PermissionService.java
+++ b/src/main/java/de/fearnixx/jeak/service/permission/base/PermissionService.java
@@ -27,6 +27,7 @@ public class PermissionService implements IPermissionService {
     private static final Logger logger = LoggerFactory.getLogger(PermissionService.class);
 
     private final Map<String, IPermissionProvider> providers = new ConcurrentHashMap<>();
+    public static final String PERSISTENCE_UNIT_NAME = "teamspeak";
 
     @Inject
     private IDatabaseService databaseService;
@@ -44,14 +45,14 @@ public class PermissionService implements IPermissionService {
     public void onPreInitialize(IBotStateEvent.IPreInitializeEvent event) {
         AbstractTS3PermissionProvider provider;
 
-        Optional<IPersistenceUnit> optPersistenceUnit = databaseService.getPersistenceUnit("ts3perms");
+        Optional<IPersistenceUnit> optPersistenceUnit = databaseService.getPersistenceUnit(PERSISTENCE_UNIT_NAME);
         if (optPersistenceUnit.isPresent()) {
             logger.info("Persistence unit available! Using faster db-supported algorithm.");
             provider = new DBPermissionProvider();
 
         } else  {
             logger.warn("Persistence unit not available. Expect degraded performance in permission-checks.");
-            logger.info("Please consider registering persistence unit \"ts3perms\" to enable direct database access.");
+            logger.info("Please consider registering persistence unit \"{}\" to enable direct database access.", PERSISTENCE_UNIT_NAME);
             provider = new QueryPermissionProvider();
         }
 

--- a/src/main/java/de/fearnixx/jeak/service/teamspeak/AbstractUserService.java
+++ b/src/main/java/de/fearnixx/jeak/service/teamspeak/AbstractUserService.java
@@ -1,0 +1,44 @@
+package de.fearnixx.jeak.service.teamspeak;
+
+import de.fearnixx.jeak.reflect.Inject;
+import de.fearnixx.jeak.teamspeak.cache.IDataCache;
+import de.fearnixx.jeak.teamspeak.data.IClient;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public abstract class AbstractUserService implements IUserService {
+
+    @Inject
+    private IDataCache dataCache;
+
+    @Override
+    public List<IClient> findClientByUniqueID(String ts3uniqueID) {
+        return dataCache.getClients()
+                .stream()
+                .filter(client -> client.getClientUniqueID().startsWith(ts3uniqueID))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<IClient> findClientByDBID(int ts3dbID) {
+        return dataCache.getClients()
+                .stream()
+                .filter(client -> client.getClientDBID().equals(ts3dbID))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<IClient> findClientByNickname(String ts3nickname) {
+        return dataCache.getClients()
+                .stream()
+                .filter(client -> client.getNickName().toLowerCase().contains(ts3nickname.toLowerCase()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<IClient> getClientByID(int clientId) {
+        return Optional.ofNullable(dataCache.getClientMap().getOrDefault(clientId, null));
+    }
+}

--- a/src/main/java/de/fearnixx/jeak/service/teamspeak/DBUserService.java
+++ b/src/main/java/de/fearnixx/jeak/service/teamspeak/DBUserService.java
@@ -1,0 +1,159 @@
+package de.fearnixx.jeak.service.teamspeak;
+
+import de.fearnixx.jeak.reflect.FrameworkService;
+import de.fearnixx.jeak.reflect.Inject;
+import de.fearnixx.jeak.service.database.IPersistenceUnit;
+import de.fearnixx.jeak.teamspeak.IServer;
+import de.fearnixx.jeak.teamspeak.PropertyKeys;
+import de.fearnixx.jeak.teamspeak.cache.IDataCache;
+import de.fearnixx.jeak.teamspeak.data.IClient;
+import de.fearnixx.jeak.teamspeak.data.IUser;
+import de.fearnixx.jeak.teamspeak.data.TS3User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+@FrameworkService(serviceInterface = IUserService.class)
+public class DBUserService extends AbstractUserService {
+
+    private static final Logger logger = LoggerFactory.getLogger(DBUserService.class);
+
+    private IPersistenceUnit persistenceUnit;
+
+    @Inject
+    private IServer server;
+
+    @Inject
+    private IDataCache dataCache;
+
+    public DBUserService(IPersistenceUnit persistenceUnit) {
+        this.persistenceUnit = persistenceUnit;
+    }
+
+    @Override
+    public List<IUser> findUserByUniqueID(String ts3uniqueID) {
+        List<TS3User> results = new LinkedList<>();
+        withConnection(conn -> {
+            String query = "SELECT * FROM clients c WHERE c.client_unique_id = ? AND c.server_id = ?";
+            getUsersFromDB(results, conn, query, ts3uniqueID);
+            populateOrRemoveUsers(results, conn);
+        });
+        return new ArrayList<>(results);
+    }
+
+    @Override
+    public List<IUser> findUserByDBID(int ts3dbID) {
+        List<TS3User> results = new LinkedList<>();
+        withConnection(conn -> {
+            String query = "SELECT * FROM clients c WHERE c.client_id = ? AND c.server_id = ?";
+            getUsersFromDB(results, conn, query, ts3dbID);
+        });
+        return new ArrayList<>(results);
+    }
+
+    @Override
+    public List<IUser> findUserByNickname(String ts3nickname) {
+        List<TS3User> results = new LinkedList<>();
+        withConnection(conn -> {
+            String query = "SELECT * FROM clients c WHERE c.client_nickname LIKE ? AND c.server_id = ?";
+            getUsersFromDB(results, conn, query, "%" + ts3nickname + "%");
+        });
+        return new ArrayList<>(results);
+    }
+
+    private void getUsersFromDB(List<TS3User> results, Connection conn, String query, Object search) {
+        try (PreparedStatement statement = conn.prepareStatement(query)) {
+            statement.setObject(1, search);
+            statement.setInt(2, server.getInstanceId());
+            ResultSet result = statement.executeQuery();
+
+            if (!result.isBeforeFirst()) {
+                logger.warn("Failed to get client for search: {} - no entry present.", search);
+            }
+
+            while (result.next()) {
+                TS3User user = new TS3User();
+                user.setProperty(PropertyKeys.Client.ID, result.getInt("client_id"));
+                user.setProperty(PropertyKeys.Client.UID, result.getString("client_unique_id"));
+                user.setProperty(PropertyKeys.Client.NICKNAME, result.getString("client_nickname"));
+                user.setProperty(PropertyKeys.Client.LAST_JOIN_TIME, result.getLong("client_lastconnected"));
+                user.setProperty(PropertyKeys.DBClient.TOTAL_CONNECTIONS, result.getInt(PropertyKeys.DBClient.TOTAL_CONNECTIONS));
+                user.setProperty(PropertyKeys.Client.IPV4_ADDRESS, result.getString("client_lastip"));
+                results.add(user);
+                logger.debug("Constructed user: {}/{}", user.getClientDBID(), user.getNickName());
+            }
+        } catch (SQLException e) {
+            results.clear();
+            logger.error("Failed to construct results from SQL result set!", e);
+        }
+    }
+
+    private void populateOrRemoveUsers(List<TS3User> results, Connection connection) {
+        results.removeIf(user -> {
+            Integer dbId = user.getClientDBID();
+            String query = "SELECT prop.ident, prop.value FROM client_properties prop WHERE prop.id = ? AND prop.server_id = ?";
+            try (PreparedStatement statement = connection.prepareStatement(query)) {
+                statement.setInt(1, dbId);
+                statement.setInt(2, server.getInstanceId());
+                ResultSet result = statement.executeQuery();
+
+                if (!result.isBeforeFirst()) {
+                    logger.warn("No client properties found for user: {}/{}", user.getClientDBID(), user.getNickName());
+                    // This user could not be populated - remove it!
+                    return true;
+                }
+
+                while (result.next()) {
+                    String key = result.getString("ident");
+                    String value = result.getString("value");
+                    user.setProperty(key, value);
+                    logger.debug("Adding client property: {}={}", key, value);
+                }
+
+                // Properties read - everything's fine.
+                return false;
+            } catch (SQLException e) {
+                logger.error("Failed to get client properties for user: {}/{}", user.getClientDBID(), user.getNickName());
+                // This user could not be populated - remove it!
+                return true;
+            }
+        });
+    }
+
+    @Override
+    public List<IClient> findClientByUniqueID(String ts3uniqueID) {
+        return null;
+    }
+
+    @Override
+    public List<IClient> findClientByDBID(int ts3dbID) {
+        return null;
+    }
+
+    @Override
+    public List<IClient> findClientByNickname(String ts3nickname) {
+        return null;
+    }
+
+    @Override
+    public Optional<IClient> getClientByID(int clientId) {
+        return Optional.empty();
+    }
+
+    private synchronized void withConnection(Consumer<Connection> consumer) {
+        try {
+            consumer.accept(persistenceUnit.getDataSource().getConnection());
+        } catch (SQLException e) {
+            logger.error("Failed to get database connection!", e);
+        }
+    }
+}

--- a/src/main/java/de/fearnixx/jeak/service/teamspeak/QueryUserService.java
+++ b/src/main/java/de/fearnixx/jeak/service/teamspeak/QueryUserService.java
@@ -1,0 +1,133 @@
+package de.fearnixx.jeak.service.teamspeak;
+
+import de.fearnixx.jeak.event.IQueryEvent;
+import de.fearnixx.jeak.reflect.FrameworkService;
+import de.fearnixx.jeak.reflect.Inject;
+import de.fearnixx.jeak.teamspeak.IServer;
+import de.fearnixx.jeak.teamspeak.cache.IDataCache;
+import de.fearnixx.jeak.teamspeak.data.IClient;
+import de.fearnixx.jeak.teamspeak.data.IUser;
+import de.fearnixx.jeak.teamspeak.data.TS3User;
+import de.fearnixx.jeak.teamspeak.query.BlockingRequest;
+import de.fearnixx.jeak.teamspeak.query.IQueryRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+@FrameworkService(serviceInterface = IUserService.class)
+public class QueryUserService extends AbstractUserService {
+
+    private static final Logger logger = LoggerFactory.getLogger(QueryUserService.class);
+
+    @Inject
+    private IDataCache dataCache;
+
+    @Inject
+    private IServer server;
+
+    @Override
+    public List<IUser> findUserByUniqueID(String ts3uniqueID) {
+        List<IClient> onlineClients = findClientByUniqueID(ts3uniqueID);
+        if (!onlineClients.isEmpty()) {
+            return new LinkedList<>(onlineClients);
+        }
+
+        IQueryRequest request = IQueryRequest.builder()
+                .command("clientdbfind")
+                .addKey("pattern", ts3uniqueID)
+                .addOption("-uid")
+                .build();
+
+        BlockingRequest blockingRequest = new BlockingRequest(request);
+        server.getConnection().sendRequest(request);
+        if (!blockingRequest.waitForCompletion()) {
+            logger.warn("Failed to get client DB ID (by uid) from blocking request.");
+            return Collections.emptyList();
+        }
+
+        IQueryEvent.IAnswer answer = blockingRequest.getAnswer();
+        if (answer.getErrorCode() != 0) {
+            logger.warn("Error while getting client DB ID (by uid): {} - {}", answer.getErrorCode(), answer.getErrorMessage());
+            return Collections.emptyList();
+        }
+
+        return findUsersFromSearchAnswer(answer);
+    }
+
+    @Override
+    public List<IUser> findUserByDBID(int ts3dbID) {
+        List<IClient> onlineClients = findClientByDBID(ts3dbID);
+        if (!onlineClients.isEmpty()) {
+            return new LinkedList<>(onlineClients);
+        }
+
+        IQueryRequest request = IQueryRequest.builder()
+                .command("clientdbinfo")
+                .addKey("cldbid", ts3dbID)
+                .build();
+
+        BlockingRequest blockingRequest = new BlockingRequest(request);
+        server.getConnection().sendRequest(request);
+        if (!blockingRequest.waitForCompletion()) {
+            logger.warn("Failed to get user from blocking request.");
+            return Collections.emptyList();
+        }
+
+        IQueryEvent.IAnswer answer = blockingRequest.getAnswer();
+        if (answer.getErrorCode() != 0) {
+            logger.warn("Error getting client from db request: {} - {}", answer.getErrorCode(), answer.getErrorMessage());
+            return Collections.emptyList();
+        }
+
+        List<IUser> result = new LinkedList<>();
+        answer.getDataChain()
+                .stream()
+                .map(data -> (TS3User) new TS3User().copyFrom(data))
+                .forEach(result::add);
+        return result;
+    }
+
+    @Override
+    public List<IUser> findUserByNickname(String ts3nickname) {
+        List<IClient> onlineClients = findClientByNickname(ts3nickname);
+        if (!onlineClients.isEmpty()) {
+            return new LinkedList<>(onlineClients);
+        }
+
+        IQueryRequest request = IQueryRequest.builder()
+                .command("clientdbfind")
+                .addKey("pattern", ts3nickname)
+                .build();
+
+        BlockingRequest blockingRequest = new BlockingRequest(request);
+        server.getConnection().sendRequest(request);
+        if (!blockingRequest.waitForCompletion()) {
+            logger.warn("Failed to get client DB ID (by nickname) from blocking request.");
+            return Collections.emptyList();
+        }
+
+        IQueryEvent.IAnswer answer = blockingRequest.getAnswer();
+        if (answer.getErrorCode() != 0) {
+            logger.warn("Error while getting client DB ID (by nickname): {} - {}", answer.getErrorCode(), answer.getErrorMessage());
+            return Collections.emptyList();
+        }
+
+        return findUsersFromSearchAnswer(answer);
+    }
+
+    private List<IUser> findUsersFromSearchAnswer(IQueryEvent.IAnswer answer) {
+        final List<IUser> results = new LinkedList<>();
+        answer.getDataChain()
+                .stream()
+                .map(holder -> holder.getProperty("cldbid").orElse(null))
+                .filter(Objects::nonNull)
+                .map(Integer::parseInt)
+                .map(this::findUserByDBID)
+                .forEach(results::addAll);
+        return results;
+    }
+}

--- a/src/main/java/de/fearnixx/jeak/service/teamspeak/UserService.java
+++ b/src/main/java/de/fearnixx/jeak/service/teamspeak/UserService.java
@@ -11,6 +11,8 @@ import de.fearnixx.jeak.service.database.IPersistenceUnit;
 import de.fearnixx.jeak.service.event.IEventService;
 import de.fearnixx.jeak.teamspeak.data.IClient;
 import de.fearnixx.jeak.teamspeak.data.IUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,6 +24,7 @@ import java.util.Optional;
 public class UserService implements IUserService {
 
     public static final String PERSISTENCE_UNIT_NAME = "teamspeak";
+    private static final Logger logger = LoggerFactory.getLogger(UserService.class);
 
     @Inject
     private IDatabaseService databaseService;
@@ -38,8 +41,11 @@ public class UserService implements IUserService {
     public void onPreInitialize(IBotStateEvent.IPreInitializeEvent event) {
         Optional<IPersistenceUnit> optUnit = databaseService.getPersistenceUnit(PERSISTENCE_UNIT_NAME);
         if (optUnit.isPresent()) {
+            logger.info("Persistence unit available! Using faster db-supported algorithm.");
             serviceImplementation = new DBUserService(optUnit.get());
         } else {
+            logger.warn("Persistence unit not available. Expect degraded performance in offline user retrieval.");
+            logger.info("Please consider registering persistence unit \"{}\" to enable direct database access.", PERSISTENCE_UNIT_NAME);
             serviceImplementation = new QueryUserService();
         }
 

--- a/src/main/java/de/fearnixx/jeak/service/teamspeak/UserService.java
+++ b/src/main/java/de/fearnixx/jeak/service/teamspeak/UserService.java
@@ -1,0 +1,128 @@
+package de.fearnixx.jeak.service.teamspeak;
+
+import de.fearnixx.jeak.event.IQueryEvent;
+import de.fearnixx.jeak.reflect.Inject;
+import de.fearnixx.jeak.teamspeak.cache.IDataCache;
+import de.fearnixx.jeak.teamspeak.data.IClient;
+import de.fearnixx.jeak.teamspeak.data.IUser;
+import de.fearnixx.jeak.teamspeak.query.BlockingRequest;
+import de.fearnixx.jeak.teamspeak.query.IQueryRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class UserService implements IUserService {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserService.class);
+
+    @Inject
+    private IDataCache dataCache;
+
+    @Override
+    public List<IUser> findUserByUniqueID(String ts3uniqueID) {
+        IQueryRequest request = IQueryRequest.builder()
+                .command("clientdbfind")
+                .addKey("pattern", ts3uniqueID)
+                .addOption("uid")
+                .build();
+
+        BlockingRequest blockingRequest = new BlockingRequest(request);
+        if (!blockingRequest.waitForCompletion()) {
+            logger.warn("Failed to get client DB ID (by uid) from blocking request.");
+            return Collections.emptyList();
+        }
+
+        IQueryEvent.IAnswer answer = blockingRequest.getAnswer();
+        if (answer.getErrorCode() != 0) {
+            logger.warn("Error while getting client DB ID (by uid): {} - {}", answer.getErrorCode(), answer.getErrorMessage());
+            return Collections.emptyList();
+        }
+
+        return findUsersFromSearchAnswer(answer);
+    }
+
+    @Override
+    public List<IUser> findUserByDBID(int ts3dbID) {
+        IQueryRequest request = IQueryRequest.builder()
+                .command("clientdbinfo")
+                .addKey("cldbid", ts3dbID)
+                .build();
+
+        BlockingRequest blockingRequest = new BlockingRequest(request);
+        if (!blockingRequest.waitForCompletion()) {
+            logger.warn("Failed to get user from blocking request.");
+            return Collections.emptyList();
+        }
+
+        IQueryEvent.IAnswer answer = blockingRequest.getAnswer();
+        if (answer.getErrorCode() != 0) {
+            logger.warn("Error getting client from db request: {} - {}", answer.getErrorCode(), answer.getErrorMessage());
+            return Collections.emptyList();
+        }
+
+        
+    }
+
+    @Override
+    public List<IUser> findUserByNickname(String ts3nickname) {
+        IQueryRequest request = IQueryRequest.builder()
+                .command("clientdbfind")
+                .addKey("pattern", ts3nickname)
+                .build();
+
+        BlockingRequest blockingRequest = new BlockingRequest(request);
+        if (!blockingRequest.waitForCompletion()) {
+            logger.warn("Failed to get client DB ID (by nickname) from blocking request.");
+            return Collections.emptyList();
+        }
+
+        IQueryEvent.IAnswer answer = blockingRequest.getAnswer();
+        if (answer.getErrorCode() != 0) {
+            logger.warn("Error while getting client DB ID (by nickname): {} - {}", answer.getErrorCode(), answer.getErrorMessage());
+            return Collections.emptyList();
+        }
+
+        return findUsersFromSearchAnswer(answer);
+    }
+
+    private List<IUser> findUsersFromSearchAnswer(IQueryEvent.IAnswer answer) {
+        final List<IUser> results = new LinkedList<>();
+        answer.getDataChain()
+                .stream()
+                .map(holder -> holder.getProperty("cldbid").orElse(null))
+                .filter(Objects::nonNull)
+                .map(Integer::parseInt)
+                .map(this::findUserByDBID)
+                .forEach(results::addAll);
+        return results;
+    }
+
+    @Override
+    public List<IClient> findClientByUniqueID(String ts3uniqueID) {
+        return dataCache.getClients()
+                .stream()
+                .filter(client -> client.getClientUniqueID().startsWith(ts3uniqueID))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<IClient> findClientByDBID(int ts3dbID) {
+        return dataCache.getClients()
+                .stream()
+                .filter(client -> client.getClientDBID().equals(ts3dbID))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<IClient> findClientByNickname(String ts3nickname) {
+        return dataCache.getClients()
+                .stream()
+                .filter(client -> client.getNickName().toLowerCase().contains(ts3nickname.toLowerCase()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/de/fearnixx/jeak/service/teamspeak/UserService.java
+++ b/src/main/java/de/fearnixx/jeak/service/teamspeak/UserService.java
@@ -1,158 +1,84 @@
 package de.fearnixx.jeak.service.teamspeak;
 
-import de.fearnixx.jeak.event.IQueryEvent;
+import de.fearnixx.jeak.event.bot.IBotStateEvent;
 import de.fearnixx.jeak.reflect.FrameworkService;
+import de.fearnixx.jeak.reflect.IInjectionService;
 import de.fearnixx.jeak.reflect.Inject;
-import de.fearnixx.jeak.teamspeak.IServer;
-import de.fearnixx.jeak.teamspeak.cache.IDataCache;
+import de.fearnixx.jeak.reflect.Listener;
+import de.fearnixx.jeak.service.IServiceManager;
+import de.fearnixx.jeak.service.database.IDatabaseService;
+import de.fearnixx.jeak.service.database.IPersistenceUnit;
+import de.fearnixx.jeak.service.event.IEventService;
 import de.fearnixx.jeak.teamspeak.data.IClient;
 import de.fearnixx.jeak.teamspeak.data.IUser;
-import de.fearnixx.jeak.teamspeak.data.TS3User;
-import de.fearnixx.jeak.teamspeak.query.BlockingRequest;
-import de.fearnixx.jeak.teamspeak.query.IQueryRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
+/**
+ * Small loader around the user service that decides whether or not to use direct DB access or queries.
+ */
 @FrameworkService(serviceInterface = IUserService.class)
 public class UserService implements IUserService {
 
-    private static final Logger logger = LoggerFactory.getLogger(UserService.class);
+    public static final String PERSISTENCE_UNIT_NAME = "teamspeak";
 
     @Inject
-    private IDataCache dataCache;
+    private IDatabaseService databaseService;
 
     @Inject
-    private IServer server;
+    private IEventService eventService;
+
+    @Inject
+    private IInjectionService injectionService;
+
+    private IUserService serviceImplementation;
+
+    @Listener
+    public void onPreInitialize(IBotStateEvent.IPreInitializeEvent event) {
+        Optional<IPersistenceUnit> optUnit = databaseService.getPersistenceUnit(PERSISTENCE_UNIT_NAME);
+        if (optUnit.isPresent()) {
+            serviceImplementation = new DBUserService(optUnit.get());
+        } else {
+            serviceImplementation = new QueryUserService();
+        }
+
+        eventService.registerListener(serviceImplementation);
+        injectionService.injectInto(serviceImplementation);
+    }
 
     @Override
     public List<IUser> findUserByUniqueID(String ts3uniqueID) {
-        List<IClient> onlineClients = findClientByUniqueID(ts3uniqueID);
-        if (!onlineClients.isEmpty()) {
-            return new LinkedList<>(onlineClients);
-        }
-
-        IQueryRequest request = IQueryRequest.builder()
-                .command("clientdbfind")
-                .addKey("pattern", ts3uniqueID)
-                .addOption("-uid")
-                .build();
-
-        BlockingRequest blockingRequest = new BlockingRequest(request);
-        server.getConnection().sendRequest(request);
-        if (!blockingRequest.waitForCompletion()) {
-            logger.warn("Failed to get client DB ID (by uid) from blocking request.");
-            return Collections.emptyList();
-        }
-
-        IQueryEvent.IAnswer answer = blockingRequest.getAnswer();
-        if (answer.getErrorCode() != 0) {
-            logger.warn("Error while getting client DB ID (by uid): {} - {}", answer.getErrorCode(), answer.getErrorMessage());
-            return Collections.emptyList();
-        }
-
-        return findUsersFromSearchAnswer(answer);
+        return serviceImplementation.findUserByUniqueID(ts3uniqueID);
     }
 
     @Override
     public List<IUser> findUserByDBID(int ts3dbID) {
-        List<IClient> onlineClients = findClientByDBID(ts3dbID);
-        if (!onlineClients.isEmpty()) {
-            return new LinkedList<>(onlineClients);
-        }
-
-        IQueryRequest request = IQueryRequest.builder()
-                .command("clientdbinfo")
-                .addKey("cldbid", ts3dbID)
-                .build();
-
-        BlockingRequest blockingRequest = new BlockingRequest(request);
-        server.getConnection().sendRequest(request);
-        if (!blockingRequest.waitForCompletion()) {
-            logger.warn("Failed to get user from blocking request.");
-            return Collections.emptyList();
-        }
-
-        IQueryEvent.IAnswer answer = blockingRequest.getAnswer();
-        if (answer.getErrorCode() != 0) {
-            logger.warn("Error getting client from db request: {} - {}", answer.getErrorCode(), answer.getErrorMessage());
-            return Collections.emptyList();
-        }
-
-        List<IUser> result = new LinkedList<>();
-        answer.getDataChain()
-                .stream()
-                .map(data -> (TS3User) new TS3User().copyFrom(data))
-                .forEach(result::add);
-        return result;
+        return serviceImplementation.findUserByDBID(ts3dbID);
     }
 
     @Override
     public List<IUser> findUserByNickname(String ts3nickname) {
-        List<IClient> onlineClients = findClientByNickname(ts3nickname);
-        if (!onlineClients.isEmpty()) {
-            return new LinkedList<>(onlineClients);
-        }
-
-        IQueryRequest request = IQueryRequest.builder()
-                .command("clientdbfind")
-                .addKey("pattern", ts3nickname)
-                .build();
-
-        BlockingRequest blockingRequest = new BlockingRequest(request);
-        server.getConnection().sendRequest(request);
-        if (!blockingRequest.waitForCompletion()) {
-            logger.warn("Failed to get client DB ID (by nickname) from blocking request.");
-            return Collections.emptyList();
-        }
-
-        IQueryEvent.IAnswer answer = blockingRequest.getAnswer();
-        if (answer.getErrorCode() != 0) {
-            logger.warn("Error while getting client DB ID (by nickname): {} - {}", answer.getErrorCode(), answer.getErrorMessage());
-            return Collections.emptyList();
-        }
-
-        return findUsersFromSearchAnswer(answer);
-    }
-
-    private List<IUser> findUsersFromSearchAnswer(IQueryEvent.IAnswer answer) {
-        final List<IUser> results = new LinkedList<>();
-        answer.getDataChain()
-                .stream()
-                .map(holder -> holder.getProperty("cldbid").orElse(null))
-                .filter(Objects::nonNull)
-                .map(Integer::parseInt)
-                .map(this::findUserByDBID)
-                .forEach(results::addAll);
-        return results;
+        return serviceImplementation.findUserByNickname(ts3nickname);
     }
 
     @Override
     public List<IClient> findClientByUniqueID(String ts3uniqueID) {
-        return dataCache.getClients()
-                .stream()
-                .filter(client -> client.getClientUniqueID().startsWith(ts3uniqueID))
-                .collect(Collectors.toList());
+        return serviceImplementation.findClientByUniqueID(ts3uniqueID);
     }
 
     @Override
     public List<IClient> findClientByDBID(int ts3dbID) {
-        return dataCache.getClients()
-                .stream()
-                .filter(client -> client.getClientDBID().equals(ts3dbID))
-                .collect(Collectors.toList());
+        return serviceImplementation.findClientByDBID(ts3dbID);
     }
 
     @Override
     public List<IClient> findClientByNickname(String ts3nickname) {
-        return dataCache.getClients()
-                .stream()
-                .filter(client -> client.getNickName().toLowerCase().contains(ts3nickname.toLowerCase()))
-                .collect(Collectors.toList());
+        return serviceImplementation.findClientByNickname(ts3nickname);
+    }
+
+    @Override
+    public Optional<IClient> getClientByID(int clientId) {
+        return serviceImplementation.getClientByID(clientId);
     }
 }

--- a/src/main/java/de/fearnixx/jeak/service/teamspeak/UserService.java
+++ b/src/main/java/de/fearnixx/jeak/service/teamspeak/UserService.java
@@ -5,6 +5,7 @@ import de.fearnixx.jeak.reflect.Inject;
 import de.fearnixx.jeak.teamspeak.cache.IDataCache;
 import de.fearnixx.jeak.teamspeak.data.IClient;
 import de.fearnixx.jeak.teamspeak.data.IUser;
+import de.fearnixx.jeak.teamspeak.data.TS3User;
 import de.fearnixx.jeak.teamspeak.query.BlockingRequest;
 import de.fearnixx.jeak.teamspeak.query.IQueryRequest;
 import org.slf4j.Logger;
@@ -25,6 +26,11 @@ public class UserService implements IUserService {
 
     @Override
     public List<IUser> findUserByUniqueID(String ts3uniqueID) {
+        List<IClient> onlineClients = findClientByUniqueID(ts3uniqueID);
+        if (!onlineClients.isEmpty()) {
+            return new LinkedList<>(onlineClients);
+        }
+
         IQueryRequest request = IQueryRequest.builder()
                 .command("clientdbfind")
                 .addKey("pattern", ts3uniqueID)
@@ -48,6 +54,11 @@ public class UserService implements IUserService {
 
     @Override
     public List<IUser> findUserByDBID(int ts3dbID) {
+        List<IClient> onlineClients = findClientByDBID(ts3dbID);
+        if (!onlineClients.isEmpty()) {
+            return new LinkedList<>(onlineClients);
+        }
+
         IQueryRequest request = IQueryRequest.builder()
                 .command("clientdbinfo")
                 .addKey("cldbid", ts3dbID)
@@ -65,11 +76,21 @@ public class UserService implements IUserService {
             return Collections.emptyList();
         }
 
-        
+        List<IUser> result = new LinkedList<>();
+        answer.getDataChain()
+                .stream()
+                .map(data -> (TS3User) new TS3User().copyFrom(data))
+                .forEach(result::add);
+        return result;
     }
 
     @Override
     public List<IUser> findUserByNickname(String ts3nickname) {
+        List<IClient> onlineClients = findClientByNickname(ts3nickname);
+        if (!onlineClients.isEmpty()) {
+            return new LinkedList<>(onlineClients);
+        }
+
         IQueryRequest request = IQueryRequest.builder()
                 .command("clientdbfind")
                 .addKey("pattern", ts3nickname)

--- a/src/main/java/de/fearnixx/jeak/service/teamspeak/UserService.java
+++ b/src/main/java/de/fearnixx/jeak/service/teamspeak/UserService.java
@@ -1,6 +1,7 @@
 package de.fearnixx.jeak.service.teamspeak;
 
 import de.fearnixx.jeak.event.IQueryEvent;
+import de.fearnixx.jeak.reflect.FrameworkService;
 import de.fearnixx.jeak.reflect.Inject;
 import de.fearnixx.jeak.teamspeak.cache.IDataCache;
 import de.fearnixx.jeak.teamspeak.data.IClient;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+@FrameworkService(serviceInterface = IUserService.class)
 public class UserService implements IUserService {
 
     private static final Logger logger = LoggerFactory.getLogger(UserService.class);

--- a/src/main/java/de/fearnixx/jeak/service/teamspeak/UserService.java
+++ b/src/main/java/de/fearnixx/jeak/service/teamspeak/UserService.java
@@ -3,6 +3,7 @@ package de.fearnixx.jeak.service.teamspeak;
 import de.fearnixx.jeak.event.IQueryEvent;
 import de.fearnixx.jeak.reflect.FrameworkService;
 import de.fearnixx.jeak.reflect.Inject;
+import de.fearnixx.jeak.teamspeak.IServer;
 import de.fearnixx.jeak.teamspeak.cache.IDataCache;
 import de.fearnixx.jeak.teamspeak.data.IClient;
 import de.fearnixx.jeak.teamspeak.data.IUser;
@@ -26,6 +27,9 @@ public class UserService implements IUserService {
     @Inject
     private IDataCache dataCache;
 
+    @Inject
+    private IServer server;
+
     @Override
     public List<IUser> findUserByUniqueID(String ts3uniqueID) {
         List<IClient> onlineClients = findClientByUniqueID(ts3uniqueID);
@@ -36,10 +40,11 @@ public class UserService implements IUserService {
         IQueryRequest request = IQueryRequest.builder()
                 .command("clientdbfind")
                 .addKey("pattern", ts3uniqueID)
-                .addOption("uid")
+                .addOption("-uid")
                 .build();
 
         BlockingRequest blockingRequest = new BlockingRequest(request);
+        server.getConnection().sendRequest(request);
         if (!blockingRequest.waitForCompletion()) {
             logger.warn("Failed to get client DB ID (by uid) from blocking request.");
             return Collections.emptyList();
@@ -67,6 +72,7 @@ public class UserService implements IUserService {
                 .build();
 
         BlockingRequest blockingRequest = new BlockingRequest(request);
+        server.getConnection().sendRequest(request);
         if (!blockingRequest.waitForCompletion()) {
             logger.warn("Failed to get user from blocking request.");
             return Collections.emptyList();
@@ -99,6 +105,7 @@ public class UserService implements IUserService {
                 .build();
 
         BlockingRequest blockingRequest = new BlockingRequest(request);
+        server.getConnection().sendRequest(request);
         if (!blockingRequest.waitForCompletion()) {
             logger.warn("Failed to get client DB ID (by nickname) from blocking request.");
             return Collections.emptyList();

--- a/src/main/java/de/fearnixx/jeak/teamspeak/data/TS3Client.java
+++ b/src/main/java/de/fearnixx/jeak/teamspeak/data/TS3Client.java
@@ -62,38 +62,6 @@ public class TS3Client extends TS3ClientHolder {
     }
 
     @Override
-    public IQueryRequest addServerGroup(Integer... serverGroupIds) {
-        QueryBuilder queryBuilder = IQueryRequest.builder()
-                .command(QueryCommands.SERVER_GROUP.SERVERGROUP_ADD_CLIENT)
-                .addKey("cldbid", this.getClientDBID());
-        Arrays.stream(serverGroupIds).forEach(id -> {
-            queryBuilder.addKey("sgid", id).commitChainElement();
-        });
-        return queryBuilder.build();
-    }
-
-    @Override
-    public IQueryRequest removeServerGroup(Integer... serverGroupIds) {
-        QueryBuilder queryBuilder = IQueryRequest.builder()
-                .command(QueryCommands.SERVER_GROUP.SERVERGROUP_DEL_CLIENT)
-                .addKey("cldbid", this.getClientDBID());
-        Arrays.stream(serverGroupIds).forEach(id -> {
-            queryBuilder.addKey("sgid", id).commitChainElement();
-        });
-        return queryBuilder.build();
-    }
-
-    @Override
-    public IQueryRequest setChannelGroup(Integer channelId, Integer channelGroupId) {
-        return IQueryRequest.builder()
-                .command(QueryCommands.CLIENT.CLIENT_SET_CHANNEL_GROUP)
-                .addKey("cldbid", this.getClientDBID())
-                .addKey(PropertyKeys.Channel.ID, channelId)
-                .addKey("cgid", channelGroupId)
-                .build();
-    }
-
-    @Override
     public IQueryRequest kickFromServer(String reasonMessage) {
         return kick(KickType.FROM_SERVER, reasonMessage);
     }

--- a/src/main/java/de/fearnixx/jeak/teamspeak/data/TS3ClientHolder.java
+++ b/src/main/java/de/fearnixx/jeak/teamspeak/data/TS3ClientHolder.java
@@ -1,21 +1,18 @@
 package de.fearnixx.jeak.teamspeak.data;
 
-import de.fearnixx.jeak.event.query.RawQueryEvent;
 import de.fearnixx.jeak.teamspeak.PropertyKeys;
 import de.fearnixx.jeak.teamspeak.except.ConsistencyViolationException;
 
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-public abstract class TS3ClientHolder extends RawQueryEvent.Message implements IClient {
+public abstract class TS3ClientHolder extends TS3User implements IClient {
 
     private boolean invalidated = false;
 
-    public TS3ClientHolder(){
+    public TS3ClientHolder() {
         super();
     }
 
@@ -29,15 +26,6 @@ public abstract class TS3ClientHolder extends RawQueryEvent.Message implements I
     }
 
     @Override
-    public String getClientUniqueID() {
-        Optional<String> optProperty = getProperty(PropertyKeys.Client.UID);
-        if (!optProperty.isPresent())
-            throw new ConsistencyViolationException("Client is missing unique ID")
-                    .setSourceObject(this);
-        return optProperty.get();
-    }
-
-    @Override
     public Integer getClientID() {
         Optional<String> optProperty = getProperty(PropertyKeys.Client.ID);
         if (!optProperty.isPresent())
@@ -47,37 +35,20 @@ public abstract class TS3ClientHolder extends RawQueryEvent.Message implements I
     }
 
     @Override
-    public Integer getClientDBID() {
-        Optional<String> optProperty = getProperty(PropertyKeys.Client.DBID);
-        if (!optProperty.isPresent())
-            throw new ConsistencyViolationException("Client is missing database ID")
-                    .setSourceObject(this);
-        return Integer.parseInt(optProperty.get());
-    }
-
-    @Override
-    public String getNickName() {
-        Optional<String> optProperty = getProperty(PropertyKeys.Client.NICKNAME);
-        if (!optProperty.isPresent())
-            throw new ConsistencyViolationException("Client is missing nickname")
-                    .setSourceObject(this);
-        return optProperty.get();
-    }
-
-    @Override
-    public String getIconID() {
-        return getProperty(PropertyKeys.Client.ICON_ID).orElse("0");
-    }
-
-    @Override
     public PlatformType getPlatform() {
         switch (getProperty(PropertyKeys.Client.PLATFORM).orElse("unknown").toLowerCase()) {
-            case "windows": return PlatformType.WINDOWS;
-            case "android": return PlatformType.ANDROID;
-            case "linux": return PlatformType.LINUX;
-            case "ios": return PlatformType.IOS;
-            case "os: x": return PlatformType.OSX;
-            default: return PlatformType.UNKNOWN;
+            case "windows":
+                return PlatformType.WINDOWS;
+            case "android":
+                return PlatformType.ANDROID;
+            case "linux":
+                return PlatformType.LINUX;
+            case "ios":
+                return PlatformType.IOS;
+            case "os: x":
+                return PlatformType.OSX;
+            default:
+                return PlatformType.UNKNOWN;
         }
     }
 
@@ -184,48 +155,8 @@ public abstract class TS3ClientHolder extends RawQueryEvent.Message implements I
     }
 
     @Override
-    public List<Integer> getGroupIDs() {
-        Optional<String> optProperty = getProperty(PropertyKeys.Client.GROUPS);
-        if (!optProperty.isPresent())
-            throw new ConsistencyViolationException("Client has no server groups")
-                    .setSourceObject(this);
-
-        String s = optProperty.get();
-        String[] sIDs = s.split(",");
-        Integer[] ids = new Integer[sIDs.length];
-        for (int i = 0; i < sIDs.length; i++) {
-            ids[i] = Integer.parseInt(sIDs[i]);
-        }
-        return Collections.unmodifiableList(Arrays.asList(ids));
-    }
-
-    @Override
     public Integer getIdleTime() {
         return Integer.parseInt(getProperty(PropertyKeys.Client.IDLE_TIME).orElse("0"));
-    }
-
-    @Override
-    public Long getCreated() {
-        Optional<String> optProperty = getProperty(PropertyKeys.Client.CREATED_TIME);
-        if (!optProperty.isPresent())
-            throw new ConsistencyViolationException("Client is missing creation timestamp")
-                    .setSourceObject(this);
-        return Long.parseLong(optProperty.get());
-    }
-
-    @Override
-    public LocalDateTime getCreatedTime() {
-        return LocalDateTime.ofEpochSecond(getCreated(), 0, ZoneOffset.UTC);
-    }
-
-    @Override
-    public Long getLastJoin() {
-        return Long.parseLong(getProperty(PropertyKeys.Client.LAST_JOIN_TIME).orElse("0"));
-    }
-
-    @Override
-    public LocalDateTime getLastJoinTime() {
-        return LocalDateTime.ofEpochSecond(getLastJoin(), 0, ZoneOffset.UTC);
     }
 
     @Override

--- a/src/main/java/de/fearnixx/jeak/teamspeak/data/TS3User.java
+++ b/src/main/java/de/fearnixx/jeak/teamspeak/data/TS3User.java
@@ -1,0 +1,43 @@
+package de.fearnixx.jeak.teamspeak.data;
+
+import de.fearnixx.jeak.teamspeak.PropertyKeys;
+import de.fearnixx.jeak.teamspeak.QueryCommands;
+import de.fearnixx.jeak.teamspeak.query.IQueryRequest;
+import de.fearnixx.jeak.teamspeak.query.QueryBuilder;
+
+import java.util.Arrays;
+
+public class TS3User extends TS3UserHolder {
+
+    @Override
+    public IQueryRequest addServerGroup(Integer... serverGroupIds) {
+        QueryBuilder queryBuilder = IQueryRequest.builder()
+                .command(QueryCommands.SERVER_GROUP.SERVERGROUP_ADD_CLIENT)
+                .addKey("cldbid", this.getClientDBID());
+        Arrays.stream(serverGroupIds).forEach(id -> {
+            queryBuilder.addKey("sgid", id).commitChainElement();
+        });
+        return queryBuilder.build();
+    }
+
+    @Override
+    public IQueryRequest removeServerGroup(Integer... serverGroupIds) {
+        QueryBuilder queryBuilder = IQueryRequest.builder()
+                .command(QueryCommands.SERVER_GROUP.SERVERGROUP_DEL_CLIENT)
+                .addKey("cldbid", this.getClientDBID());
+        Arrays.stream(serverGroupIds).forEach(id -> {
+            queryBuilder.addKey("sgid", id).commitChainElement();
+        });
+        return queryBuilder.build();
+    }
+
+    @Override
+    public IQueryRequest setChannelGroup(Integer channelId, Integer channelGroupId) {
+        return IQueryRequest.builder()
+                .command(QueryCommands.CLIENT.CLIENT_SET_CHANNEL_GROUP)
+                .addKey("cldbid", this.getClientDBID())
+                .addKey(PropertyKeys.Channel.ID, channelId)
+                .addKey("cgid", channelGroupId)
+                .build();
+    }
+}

--- a/src/main/java/de/fearnixx/jeak/teamspeak/data/TS3UserHolder.java
+++ b/src/main/java/de/fearnixx/jeak/teamspeak/data/TS3UserHolder.java
@@ -41,7 +41,7 @@ public abstract class TS3UserHolder extends RawQueryEvent.Message implements IUs
     public String getDescription() {
         Optional<String> optProperty = getProperty(PropertyKeys.Client.DESCRIPTION);
         if (!optProperty.isPresent()) {
-            throw new ConsistencyViolationException("Client is missing description!"),
+            throw new ConsistencyViolationException("Client is missing description!");
         }
         return optProperty.get();
     }

--- a/src/main/java/de/fearnixx/jeak/teamspeak/data/TS3UserHolder.java
+++ b/src/main/java/de/fearnixx/jeak/teamspeak/data/TS3UserHolder.java
@@ -1,0 +1,79 @@
+package de.fearnixx.jeak.teamspeak.data;
+
+import de.fearnixx.jeak.event.query.RawQueryEvent;
+import de.fearnixx.jeak.teamspeak.PropertyKeys;
+import de.fearnixx.jeak.teamspeak.except.ConsistencyViolationException;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public abstract class TS3UserHolder extends RawQueryEvent.Message implements IUser {
+
+    public String getClientUniqueID() {
+        Optional<String> optProperty = getProperty(PropertyKeys.Client.UID);
+        if (!optProperty.isPresent())
+            throw new ConsistencyViolationException("Client is missing unique ID")
+                    .setSourceObject(this);
+        return optProperty.get();
+    }
+
+    public Integer getClientDBID() {
+        Optional<String> optProperty = getProperty(PropertyKeys.Client.DBID);
+        if (!optProperty.isPresent())
+            throw new ConsistencyViolationException("Client is missing database ID")
+                    .setSourceObject(this);
+        return Integer.parseInt(optProperty.get());
+    }
+
+    public String getNickName() {
+        Optional<String> optProperty = getProperty(PropertyKeys.Client.NICKNAME);
+        if (!optProperty.isPresent())
+            throw new ConsistencyViolationException("Client is missing nickname")
+                    .setSourceObject(this);
+        return optProperty.get();
+    }
+
+    public String getIconID() {
+        return getProperty(PropertyKeys.Client.ICON_ID).orElse("0");
+    }
+
+    public Long getCreated() {
+        Optional<String> optProperty = getProperty(PropertyKeys.Client.CREATED_TIME);
+        if (!optProperty.isPresent())
+            throw new ConsistencyViolationException("Client is missing creation timestamp")
+                    .setSourceObject(this);
+        return Long.parseLong(optProperty.get());
+    }
+
+    public LocalDateTime getCreatedTime() {
+        return LocalDateTime.ofEpochSecond(getCreated(), 0, ZoneOffset.UTC);
+    }
+
+    public Long getLastJoin() {
+        return Long.parseLong(getProperty(PropertyKeys.Client.LAST_JOIN_TIME).orElse("0"));
+    }
+
+    public LocalDateTime getLastJoinTime() {
+        return LocalDateTime.ofEpochSecond(getLastJoin(), 0, ZoneOffset.UTC);
+    }
+
+    @Override
+    public List<Integer> getGroupIDs() {
+        Optional<String> optProperty = getProperty(PropertyKeys.Client.GROUPS);
+        if (!optProperty.isPresent())
+            throw new ConsistencyViolationException("Client has no server groups")
+                    .setSourceObject(this);
+
+        String s = optProperty.get();
+        String[] sIDs = s.split(",");
+        Integer[] ids = new Integer[sIDs.length];
+        for (int i = 0; i < sIDs.length; i++) {
+            ids[i] = Integer.parseInt(sIDs[i]);
+        }
+        return Collections.unmodifiableList(Arrays.asList(ids));
+    }
+}

--- a/src/main/java/de/fearnixx/jeak/teamspeak/data/TS3UserHolder.java
+++ b/src/main/java/de/fearnixx/jeak/teamspeak/data/TS3UserHolder.java
@@ -37,6 +37,15 @@ public abstract class TS3UserHolder extends RawQueryEvent.Message implements IUs
         return optProperty.get();
     }
 
+    @Override
+    public String getDescription() {
+        Optional<String> optProperty = getProperty(PropertyKeys.Client.DESCRIPTION);
+        if (!optProperty.isPresent()) {
+            throw new ConsistencyViolationException("Client is missing description!"),
+        }
+        return optProperty.get();
+    }
+
     public String getIconID() {
         return getProperty(PropertyKeys.Client.ICON_ID).orElse("0");
     }

--- a/src/main/java/de/fearnixx/jeak/teamspeak/query/BlockingRequest.java
+++ b/src/main/java/de/fearnixx/jeak/teamspeak/query/BlockingRequest.java
@@ -1,0 +1,58 @@
+package de.fearnixx.jeak.teamspeak.query;
+
+import de.fearnixx.jeak.event.IQueryEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+public class BlockingRequest {
+
+    private static final Logger logger = LoggerFactory.getLogger(BlockingRequest.class);
+
+    private final IQueryRequest originalRequest;
+    private final Object monitor = new Object();
+    private long maxThreshold = TimeUnit.SECONDS.toMillis(30);
+    private IQueryEvent.IAnswer answer;
+
+    public BlockingRequest(IQueryRequest originalRequest) {
+        this.originalRequest = originalRequest;
+        this.originalRequest.onDone(this::onAnswer);
+    }
+
+    public BlockingRequest(IQueryRequest originalRequest, int time, TimeUnit timeUnit) {
+        this(originalRequest);
+        maxThreshold = timeUnit.toMillis(time);
+    }
+
+    public boolean waitForCompletion() {
+        synchronized (monitor) {
+            try {
+                monitor.wait(maxThreshold);
+                return answer != null;
+            } catch (IllegalMonitorStateException e) {
+                throw new RuntimeException("Failed to await request completion!", e);
+            } catch (InterruptedException e) {
+                logger.info("Blocking request interrupted during wait.");
+                return false;
+            }
+        }
+    }
+
+    private void onAnswer(IQueryEvent.IAnswer answer) {
+        synchronized (monitor) {
+            this.answer = answer;
+            monitor.notify();
+        }
+    }
+
+    public IQueryRequest getOriginalRequest() {
+        return originalRequest;
+    }
+
+    public IQueryEvent.IAnswer getAnswer() {
+        synchronized (monitor) {
+            return answer;
+        }
+    }
+}

--- a/src/test/java/de/fearnixx/jeak/test/plugin/UserServiceTest.java
+++ b/src/test/java/de/fearnixx/jeak/test/plugin/UserServiceTest.java
@@ -1,0 +1,76 @@
+package de.fearnixx.jeak.test.plugin;
+
+import de.fearnixx.jeak.event.IQueryEvent;
+import de.fearnixx.jeak.reflect.Inject;
+import de.fearnixx.jeak.reflect.JeakBotPlugin;
+import de.fearnixx.jeak.reflect.Listener;
+import de.fearnixx.jeak.service.teamspeak.IUserService;
+import de.fearnixx.jeak.teamspeak.cache.IDataCache;
+import de.fearnixx.jeak.teamspeak.data.IClient;
+import de.fearnixx.jeak.teamspeak.data.IUser;
+import de.fearnixx.jeak.test.AbstractTestPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+@JeakBotPlugin(id = "usersvctest")
+public class UserServiceTest extends AbstractTestPlugin {
+
+    private static final String LOOKUP_NICKNAME = "MarkL4YG";
+    private static final String LOOKUP_UNIQUE_ID = "NKLz7mUMAqrv07j1CZJ5OcDfj6I=";
+    private static final String LOOKUP_NICKNAME_OFF = "Pr0c3dur4l1mp4ct";
+    private static final String LOOKUP_UNIQUE_ID_OFF = "cZS9nRtgsAhaIVMbOwFxLmTeEvE=";
+
+    private static final Logger logger = LoggerFactory.getLogger(UserServiceTest.class);
+
+    @Inject
+    private IUserService userService;
+
+    @Inject
+    private IDataCache dataCache;
+
+    public UserServiceTest() {
+        addTest("lookup_nickname");
+        addTest("lookup_uniqueId");
+        addTest("lookup_nickname_offline");
+        addTest("lookup_uniqueId_offline");
+        addTest("lookup_live_offline_equals");
+    }
+
+    @Listener(order = Listener.Orders.LATER)
+    public void onClientRefresh(IQueryEvent.IDataEvent.IRefreshClients event) {
+        List<IClient> clientResults = userService.findClientByUniqueID(LOOKUP_UNIQUE_ID);
+        List<IClient> clientNickResults = userService.findClientByNickname(LOOKUP_NICKNAME);
+        List<IUser> userResults = userService.findUserByUniqueID(LOOKUP_UNIQUE_ID);
+
+        if (!clientResults.isEmpty()) {
+            success("lookup_uniqueId");
+        } else {
+            logger.warn("Lookup for online unique ID failed!");
+        }
+        if (!clientNickResults.isEmpty() && clientNickResults.stream().anyMatch(clientResults::contains)) {
+            success("lookup_nickname");
+        } else {
+            logger.warn("Lookup for online nickname failed!");
+        }
+        if (clientResults.equals(userResults)) {
+            success("lookup_live_offline_equals");
+        } else {
+            logger.warn("Comparision for offline & online lookup failed!");
+        }
+
+        List<IUser> offlineResults = userService.findUserByUniqueID(LOOKUP_UNIQUE_ID_OFF);
+        List<IUser> offlineNicknameResults = userService.findUserByNickname(LOOKUP_NICKNAME_OFF);
+        if (!offlineResults.isEmpty()) {
+            success("lookup_uniqueId_offline");
+        } else {
+            logger.warn("Lookup for offline unique ID failed!");
+        }
+        if (!offlineNicknameResults.isEmpty()) {
+            success("lookup_nickname_offline");
+        } else {
+            logger.warn("Lookup for offline nickname failed!");
+        }
+    }
+}

--- a/src/test/java/de/fearnixx/jeak/test/plugin/UserServiceTest.java
+++ b/src/test/java/de/fearnixx/jeak/test/plugin/UserServiceTest.java
@@ -19,8 +19,8 @@ public class UserServiceTest extends AbstractTestPlugin {
 
     private static final String LOOKUP_NICKNAME = "MarkL4YG";
     private static final String LOOKUP_UNIQUE_ID = "NKLz7mUMAqrv07j1CZJ5OcDfj6I=";
-    private static final String LOOKUP_NICKNAME_OFF = "Pr0c3dur4l1mp4ct";
-    private static final String LOOKUP_UNIQUE_ID_OFF = "cZS9nRtgsAhaIVMbOwFxLmTeEvE=";
+    private static final String LOOKUP_NICKNAME_OFF = "[Testificate] Mark";
+    private static final String LOOKUP_UNIQUE_ID_OFF = "GANC6dTbew+a3A2h/8c5CGJXzsE=";
 
     private static final Logger logger = LoggerFactory.getLogger(UserServiceTest.class);
 


### PR DESCRIPTION
This PR will add the following to the framework:
* ``IUser`` as a representation of clients that are not online holding only the information provided by a database lookup.
* ``IUserService`` as a centralized way of getting ``IClient`` and ``IUser`` instances.
* ``BlockingRequest`` as a monitor-based wrapper around requests where the result is important before execution can continue. __This is reserved to essential places in a framework where callbacks or parallelism would break intuitive work flows for plugins and should only be used sparingly.__
* Caching of ``clientdbfind`` and ``clientdbinfo`` responses from TeamSpeak to improve lookup performance for repeated lookups.
* Opt-In implementation for ``clientdbfind`` and ``clientdbinfo`` where direct database access is used instead of query commands (this is way faster)
* __Deprecation__: The public contract ``IDataCache`` is now officially deprecated as ``IUserService`` should be favored instead!
* _Change_: Special-user persistence unit ``ts3perms`` has been renamed to ``teamspeak`` - this is not breaking as this has not been documented yet and currently undergoes bleeding testing.