### PR TITLE
Refactor event listeners to be invoked by lambdas instead of reflection

### DIFF
--- a/src/main/java/de/fearnixx/jeak/event/EventContainer.java
+++ b/src/main/java/de/fearnixx/jeak/event/EventContainer.java
@@ -1,10 +1,10 @@
 package de.fearnixx.jeak.event;
 
+import de.fearnixx.jeak.event.except.EventAbortException;
 import de.fearnixx.jeak.teamspeak.except.ConsistencyViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
 import java.util.List;
 
 public class EventContainer implements Runnable {
@@ -58,7 +58,7 @@ public class EventContainer implements Runnable {
                         final long duration = getListenerRuntime() / 1000;
                         resetStartedOn();
                         receiverInterrupt = false;
-                        logger.warn("Receiver interrupted forcefully after {} seconds. Listener: {}", duration, currentReceiver.getName());
+                        logger.warn("Receiver interrupted forcefully after {} seconds. Listener: {}", duration, currentReceiver.getListenerFQN());
                     }
                 }
 
@@ -97,7 +97,7 @@ public class EventContainer implements Runnable {
 
     private void logExceptionCause(Exception e) {
         Throwable cause = e.getCause() != null ? e.getCause() : e;
-        logger.warn("Failed to pass event {} to {}", event.getClass().getSimpleName(), currentReceiver.getName(), cause);
+        logger.warn("Failed to pass event {} to {}", event.getClass().getSimpleName(), currentReceiver.getListenerFQN(), cause);
     }
 
     protected void resetStartedOn() {

--- a/src/main/java/de/fearnixx/jeak/event/except/EventAbortException.java
+++ b/src/main/java/de/fearnixx/jeak/event/except/EventAbortException.java
@@ -1,4 +1,4 @@
-package de.fearnixx.jeak.event;
+package de.fearnixx.jeak.event.except;
 
 /**
  * Created by MarkL4YG on 01-Feb-18

--- a/src/main/java/de/fearnixx/jeak/event/except/EventInvocationException.java
+++ b/src/main/java/de/fearnixx/jeak/event/except/EventInvocationException.java
@@ -1,4 +1,4 @@
-package de.fearnixx.jeak.event;
+package de.fearnixx.jeak.event.except;
 
 /**
  */

--- a/src/main/java/de/fearnixx/jeak/event/except/ListenerConstructionException.java
+++ b/src/main/java/de/fearnixx/jeak/event/except/ListenerConstructionException.java
@@ -1,0 +1,24 @@
+package de.fearnixx.jeak.event.except;
+
+public class ListenerConstructionException extends RuntimeException {
+
+    public ListenerConstructionException() {
+        super();
+    }
+
+    public ListenerConstructionException(String message) {
+        super(message);
+    }
+
+    public ListenerConstructionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ListenerConstructionException(Throwable cause) {
+        super(cause);
+    }
+
+    protected ListenerConstructionException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/de/fearnixx/jeak/teamspeak/cache/DataCache.java
+++ b/src/main/java/de/fearnixx/jeak/teamspeak/cache/DataCache.java
@@ -1,31 +1,17 @@
 package de.fearnixx.jeak.teamspeak.cache;
 
 import de.fearnixx.jeak.Main;
-import de.fearnixx.jeak.event.EventAbortException;
-import de.fearnixx.jeak.event.IQueryEvent;
-import de.fearnixx.jeak.event.IRawQueryEvent;
 import de.fearnixx.jeak.event.bot.IBotStateEvent;
-import de.fearnixx.jeak.event.query.QueryEvent;
 import de.fearnixx.jeak.reflect.FrameworkService;
 import de.fearnixx.jeak.reflect.IInjectionService;
 import de.fearnixx.jeak.reflect.Inject;
 import de.fearnixx.jeak.reflect.Listener;
 import de.fearnixx.jeak.service.event.IEventService;
-import de.fearnixx.jeak.service.task.ITask;
-import de.fearnixx.jeak.service.task.ITaskService;
-import de.fearnixx.jeak.task.TaskService;
-import de.fearnixx.jeak.teamspeak.IServer;
-import de.fearnixx.jeak.teamspeak.PropertyKeys;
-import de.fearnixx.jeak.teamspeak.QueryCommands;
 import de.fearnixx.jeak.teamspeak.data.*;
-import de.fearnixx.jeak.teamspeak.query.IQueryRequest;
-import de.fearnixx.jeak.util.TS3DataFixes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 
 @FrameworkService(serviceInterface = IDataCache.class)
 public class DataCache implements IDataCache {

--- a/src/main/java/de/fearnixx/jeak/teamspeak/cache/EventDataInjector.java
+++ b/src/main/java/de/fearnixx/jeak/teamspeak/cache/EventDataInjector.java
@@ -1,6 +1,6 @@
 package de.fearnixx.jeak.teamspeak.cache;
 
-import de.fearnixx.jeak.event.EventAbortException;
+import de.fearnixx.jeak.event.except.EventAbortException;
 import de.fearnixx.jeak.event.IQueryEvent;
 import de.fearnixx.jeak.event.query.QueryEvent;
 import de.fearnixx.jeak.reflect.Listener;


### PR DESCRIPTION
At the moment, listeners are discovered and called using ``Method`` instances (which means reflection).  
This PR will change the event listener container so that it constructs lambda expressions during runtime using ``LambdaMetafactory#metaFactory``.  
This will move stuff like security checks to the construction time of the listener container instead of doing them on each invocation of the listener. As the lambdas are independent of the listener instance (``victim`` is passed on invocation), the constructed lambdas can be cached statically for the whole JVM. 

Fixes: #14 .