### PR TITLE
Upgrade to JDK 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,5 +106,5 @@ build {
 }
 
 wrapper {
-    gradleVersion '4.2.1'
+    gradleVersion '5.4.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'java'
 apply plugin: 'maven-publish'
 
 sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_11
 
 if (project.hasProperty("preRelease")) {
     apply from: './pre-release.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ def projectVersion = '1.0.0'
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_1_8
 
 if (project.hasProperty("preRelease")) {
     apply from: './pre-release.gradle'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sun Jun 02 14:05:23 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Jun 13 16:07:15 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Since Java 1.8 support has long been deprecated, it has been decided that releasing against Java 11 LTS is far more reasonable than Java 8.  
This PR updates the build scripts to build with OpenJDK 11 and a test-run in the development environment was successful.  
A test run in the test system has to follow.  
The docker image has to be updated too as it is built against OpenJDK 8.