### PR TITLE
Add null check for unannotated methods

### DIFF
--- a/src/main/java/de/fearnixx/jeak/service/controller/controller/ControllerContainer.java
+++ b/src/main/java/de/fearnixx/jeak/service/controller/controller/ControllerContainer.java
@@ -2,6 +2,8 @@ package de.fearnixx.jeak.service.controller.controller;
 
 import de.fearnixx.jeak.reflect.RequestMapping;
 import de.fearnixx.jeak.reflect.RestController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
@@ -10,6 +12,9 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class ControllerContainer {
+
+    private static final Logger logger = LoggerFactory.getLogger(ControllerContainer.class);
+
     private Object controllerObject;
     private String controllerEndpoint;
     private List<ControllerMethod> controllerMethodList;
@@ -25,13 +30,16 @@ public class ControllerContainer {
      * @param o The controler {@link Object}.
      */
     private void initControllerContainer(Object o) {
+        logger.debug("Searching for endpoints on controller: {}", o.getClass());
         this.controllerObject = o;
         this.controllerEndpoint = extractControllerRoute(o);
-        this.controllerMethodList = Arrays.stream(o.getClass().getDeclaredMethods())
-                .map(method -> new ControllerMethod(
-                        method,
-                        method.getAnnotation(RequestMapping.class).method(),
-                        method.getAnnotation(RequestMapping.class).endpoint()))
+        this.controllerMethodList = Arrays.stream(o.getClass().getMethods())
+                .filter(method -> method.getAnnotation(RequestMapping.class) != null)
+                .map(method -> {
+                    RequestMapping mapping = method.getAnnotation(RequestMapping.class);
+                    logger.debug("Found endpoint: {}: {} at: {}", mapping.method(), mapping.endpoint(), method.getName());
+                    return new ControllerMethod(method, mapping.method(), mapping.endpoint());
+                })
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Additionally, ``#getDeclaredMethods()`` was changed to ``#getMethods()`` with the following semantic changes:  
* Endpoint methods must now be public to be discovered
* Endpoint methods are now discovered transitively
  
Also added some debug logging :slightly_smiling_face: 