### PR TITLE
Allow users to customize their preferred language

### DIFF
--- a/src/api/java/de/fearnixx/jeak/service/locale/ILocalizationService.java
+++ b/src/api/java/de/fearnixx/jeak/service/locale/ILocalizationService.java
@@ -2,6 +2,7 @@ package de.fearnixx.jeak.service.locale;
 
 import de.fearnixx.jeak.event.bot.IBotStateEvent;
 import de.fearnixx.jeak.teamspeak.data.IClient;
+import de.fearnixx.jeak.teamspeak.data.IUser;
 
 import java.util.Locale;
 
@@ -31,9 +32,20 @@ public interface ILocalizationService {
      * <ul>
      *     <li>The clients custom language setting, if defined.</li>
      *     <li>The clients country flag from TS3.</li>
+     *     <li>The configured fallback locale.</li>
      * </ul>
      */
     Locale getLocaleOfClient(IClient client);
+
+    /**
+     * Returns the locale associated with a specific client.
+     * Two values will be taken into account for this:
+     * <ul>
+     *     <li>The users custom language setting, if defined.</li>
+     *     <li>The configured fallback locale.</li>
+     * </ul>
+     */
+    Locale getLocaleOfUser(IUser user);
 
     /**
      * Sets the custom language setting for the given client.

--- a/src/api/java/de/fearnixx/jeak/service/locale/ILocalizationUnit.java
+++ b/src/api/java/de/fearnixx/jeak/service/locale/ILocalizationUnit.java
@@ -1,5 +1,6 @@
 package de.fearnixx.jeak.service.locale;
 
+import de.fearnixx.jeak.teamspeak.data.IClient;
 import de.mlessmann.confort.api.IConfigNode;
 
 import java.io.File;
@@ -18,6 +19,12 @@ public interface ILocalizationUnit {
     String getUnitId();
 
     /**
+     * Returns a context for the given client.
+     * This is the recommended way of doing so as this respects the clients custom language settings.
+     */
+    ILocaleContext getContext(IClient client);
+
+    /**
      * Returns a context for the given locale.
      * If a context for the locale is not available, the default context will be returned.
      */
@@ -26,6 +33,7 @@ public interface ILocalizationUnit {
     /**
      * Returns the context for the given country code.
      * If a context is not available or the code could not be translated into a {@link Locale}, the default context will be returned.
+     * <em>Please avoid using this from version 1.1.0 and up. Use {@link #getContext(IClient)} instead.</em>
      */
     ILocaleContext getContext(String ts3CountryCode);
 

--- a/src/api/java/de/fearnixx/jeak/service/locale/ILocalizationUnit.java
+++ b/src/api/java/de/fearnixx/jeak/service/locale/ILocalizationUnit.java
@@ -1,6 +1,7 @@
 package de.fearnixx.jeak.service.locale;
 
 import de.fearnixx.jeak.teamspeak.data.IClient;
+import de.fearnixx.jeak.teamspeak.data.IUser;
 import de.mlessmann.confort.api.IConfigNode;
 
 import java.io.File;
@@ -23,6 +24,12 @@ public interface ILocalizationUnit {
      * This is the recommended way of doing so as this respects the clients custom language settings.
      */
     ILocaleContext getContext(IClient client);
+
+    /**
+     * Returns a context for the given user.
+     * This is the recommended way of doing so as this respects the users custom language settings.
+     */
+    ILocaleContext getContext(IUser user);
 
     /**
      * Returns a context for the given locale.

--- a/src/main/java/de/fearnixx/jeak/JeakBot.java
+++ b/src/main/java/de/fearnixx/jeak/JeakBot.java
@@ -168,8 +168,8 @@ public class JeakBot implements Runnable, IBot {
         server = initializeService(new Server());
         initializeService(new TaskService((pMgr.estimateCount() > 0 ? pMgr.estimateCount() : 10) * 10));
         initializeService(new DataCache());
-        initializeService(new LocalizationService());
         initializeService(new MatcherRegistry());
+        initializeService(new LocalizationService());
         if (ENABLE_TYPED_COMMANDS) {
             initializeService(new TypedCommandService());
         } else {

--- a/src/main/java/de/fearnixx/jeak/service/locale/LocaleCommand.java
+++ b/src/main/java/de/fearnixx/jeak/service/locale/LocaleCommand.java
@@ -1,0 +1,63 @@
+package de.fearnixx.jeak.service.locale;
+
+import de.fearnixx.jeak.reflect.Inject;
+import de.fearnixx.jeak.service.command.ICommandExecutionContext;
+import de.fearnixx.jeak.service.command.spec.Commands;
+import de.fearnixx.jeak.service.command.spec.ICommandSpec;
+import de.fearnixx.jeak.service.teamspeak.IUserService;
+import de.fearnixx.jeak.teamspeak.data.IUser;
+
+import java.util.Locale;
+import java.util.Optional;
+
+import static de.fearnixx.jeak.service.command.spec.Commands.argumentSpec;
+import static de.fearnixx.jeak.service.command.spec.Commands.paramSpec;
+
+public class LocaleCommand {
+
+    @Inject
+    private ILocalizationService localeService;
+
+    @Inject
+    private IUserService userService;
+
+    public ICommandSpec getCommandSpec() {
+        return Commands.commandSpec("locale", "frw:locale")
+                .parameters(
+                        paramSpec().optional(paramSpec("locale", Locale.class)),
+                        paramSpec().optional(paramSpec("user", IUser.class))
+                )
+                .executor(this::typedInvoke)
+                .build();
+    }
+
+    public ICommandSpec getArgCommandSpec() {
+        return Commands.commandSpec("locale-arg", "frw:locale-arg")
+                .arguments(
+                        argumentSpec().optional(argumentSpec("locale", "l", Locale.class)),
+                        argumentSpec().optional(argumentSpec("user", "u", IUser.class))
+                )
+                .executor(this::typedInvoke)
+                .build();
+    }
+
+    private void typedInvoke(ICommandExecutionContext ctx) {
+        Optional<Locale> optLocale = ctx.getOne("locale", Locale.class);
+        Optional<IUser> optUser = ctx.getOne("user", IUser.class);
+        if (optLocale.isPresent()) {
+            Locale selectedLocale = optLocale.get();
+            IUser target = optUser.orElse(ctx.getSender());
+
+            if ("XX".equals(selectedLocale.getLanguage())) {
+                localeService.setLocaleForClient(target.getClientUniqueID(), null);
+            } else {
+                localeService.setLocaleForClient(target.getClientUniqueID(), selectedLocale);
+            }
+        } else {
+            Locale currentLocale =
+                    optUser.map(u -> localeService.getLocaleOfUser(u))
+                            .orElseGet(() -> localeService.getLocaleOfClient(ctx.getSender()));
+            ctx.getConnection().sendRequest(ctx.getSender().sendMessage(currentLocale.toLanguageTag()));
+        }
+    }
+}

--- a/src/main/java/de/fearnixx/jeak/service/locale/LocaleCommand.java
+++ b/src/main/java/de/fearnixx/jeak/service/locale/LocaleCommand.java
@@ -50,8 +50,12 @@ public class LocaleCommand {
 
             if ("XX".equals(selectedLocale.getLanguage())) {
                 localeService.setLocaleForClient(target.getClientUniqueID(), null);
+                final String msg = "Chosen locale reset to default.";
+                ctx.getConnection().sendRequest(ctx.getSender().sendMessage(msg));
             } else {
                 localeService.setLocaleForClient(target.getClientUniqueID(), selectedLocale);
+                final String msg = "Chosen locale set to: " + selectedLocale.toLanguageTag();
+                ctx.getConnection().sendRequest(ctx.getSender().sendMessage(msg));
             }
         } else {
             Locale currentLocale =

--- a/src/main/java/de/fearnixx/jeak/service/locale/LocaleMatcher.java
+++ b/src/main/java/de/fearnixx/jeak/service/locale/LocaleMatcher.java
@@ -1,0 +1,48 @@
+package de.fearnixx.jeak.service.locale;
+
+import de.fearnixx.jeak.reflect.Inject;
+import de.fearnixx.jeak.reflect.LocaleUnit;
+import de.fearnixx.jeak.service.command.ICommandExecutionContext;
+import de.fearnixx.jeak.service.command.spec.matcher.AbstractTypeMatcher;
+import de.fearnixx.jeak.service.command.spec.matcher.BasicMatcherResponse;
+import de.fearnixx.jeak.service.command.spec.matcher.IMatcherResponse;
+import de.fearnixx.jeak.service.command.spec.matcher.IMatchingContext;
+
+import java.util.Locale;
+
+public class LocaleMatcher extends AbstractTypeMatcher<Locale> {
+
+    @Inject
+    @LocaleUnit("commandService")
+    private ILocalizationUnit localizationUnit;
+
+    @Inject
+    private ILocalizationService localeSvc;
+
+    @Override
+    protected ILocalizationUnit getLocaleUnit() {
+        return localizationUnit;
+    }
+
+    @Override
+    protected IMatcherResponse parse(ICommandExecutionContext ctx, IMatchingContext matchingContext, String extracted) {
+        if ("unset".equals(extracted)) {
+            ctx.putOrReplaceOne(matchingContext.getArgumentOrParamName(), new Locale.Builder().setLanguage("XX"));
+            ctx.getParameterIndex().getAndIncrement();
+            return BasicMatcherResponse.SUCCESS;
+        } else {
+            if (extracted.isBlank()) {
+                return getIncompatibleTypeResponse(ctx, matchingContext, extracted);
+            }
+            Locale locale = localeSvc.getLocaleForCountryId(extracted);
+            ctx.putOrReplaceOne("locale", locale);
+            ctx.getParameterIndex().getAndIncrement();
+            return BasicMatcherResponse.SUCCESS;
+        }
+    }
+
+    @Override
+    public Class<Locale> getSupportedType() {
+        return Locale.class;
+    }
+}

--- a/src/main/java/de/fearnixx/jeak/service/locale/LocalizationUnit.java
+++ b/src/main/java/de/fearnixx/jeak/service/locale/LocalizationUnit.java
@@ -1,5 +1,6 @@
 package de.fearnixx.jeak.service.locale;
 
+import de.fearnixx.jeak.teamspeak.data.IClient;
 import de.fearnixx.jeak.util.Configurable;
 import de.mlessmann.confort.LoaderFactory;
 import de.mlessmann.confort.api.IConfig;
@@ -58,6 +59,12 @@ public class LocalizationUnit extends Configurable implements ILocalizationUnit 
             logger.warn("[{}] Failed to load default language as a fallback for: {}", unitId, languageTag);
             return new LocaleContext(unitId, locale, getConfig().createNewInstance());
         }
+    }
+
+    @Override
+    public ILocaleContext getContext(IClient client) {
+        Locale locale = localizationService.getLocaleOfClient(client);
+        return getContext(locale);
     }
 
     @Override

--- a/src/main/java/de/fearnixx/jeak/service/locale/LocalizationUnit.java
+++ b/src/main/java/de/fearnixx/jeak/service/locale/LocalizationUnit.java
@@ -1,6 +1,7 @@
 package de.fearnixx.jeak.service.locale;
 
 import de.fearnixx.jeak.teamspeak.data.IClient;
+import de.fearnixx.jeak.teamspeak.data.IUser;
 import de.fearnixx.jeak.util.Configurable;
 import de.mlessmann.confort.LoaderFactory;
 import de.mlessmann.confort.api.IConfig;
@@ -64,6 +65,12 @@ public class LocalizationUnit extends Configurable implements ILocalizationUnit 
     @Override
     public ILocaleContext getContext(IClient client) {
         Locale locale = localizationService.getLocaleOfClient(client);
+        return getContext(locale);
+    }
+
+    @Override
+    public ILocaleContext getContext(IUser user) {
+        Locale locale = localizationService.getLocaleOfUser(user);
         return getContext(locale);
     }
 

--- a/src/test/java/de/fearnixx/jeak/test/plugin/LocalizationTestPlugin.java
+++ b/src/test/java/de/fearnixx/jeak/test/plugin/LocalizationTestPlugin.java
@@ -50,11 +50,14 @@ public class LocalizationTestPlugin extends AbstractTestPlugin implements IComma
 
             String enTPL = testUnit.getContext("en").uncheckedGetMessage("test.message");
             String deTPL = testUnit.getContext("de").uncheckedGetMessage("test.message");
+            String chosenTPL = testUnit.getContext(client).uncheckedGetMessage("test.message");
 
             String enMsg = String.format("Testing localization. Next should be in English: %s", enTPL);
             String deMsg = String.format("Testing localization. Next should be in German: %s", deTPL);
+            String chosenMsg = String.format("Testing localization. Next should be in your selected: %s", chosenTPL);
             ctx.getRawEvent().getConnection().sendRequest(client.sendMessage(enMsg));
             ctx.getRawEvent().getConnection().sendRequest(client.sendMessage(deMsg));
+            ctx.getRawEvent().getConnection().sendRequest(client.sendMessage(chosenMsg));
         }
     }
 }


### PR DESCRIPTION
This PR allows users to change their preferred language using the ``!locale`` or ``!locale-arg`` commands.  
It also includes a performance fix for locale contexts being re-initialized too often.  
  
The context getters taking ``Locale`` and the country code as arguments are now discouraged (but not deprecated).  
  
Closes: #118 