### PR TITLE
Remove name param from RequestBody annotation

### DIFF
--- a/src/api/java/de/fearnixx/jeak/reflect/RequestBody.java
+++ b/src/api/java/de/fearnixx/jeak/reflect/RequestBody.java
@@ -8,11 +8,8 @@ import java.lang.annotation.Target;
 /**
  * Mark a parameter to be filled by the request body of a call.
  *
- * type(): REQUIRED Specify the class of the used variable.
- *
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
 public @interface RequestBody {
-    Class<?> type();
 }

--- a/src/api/java/de/fearnixx/jeak/reflect/RequestBody.java
+++ b/src/api/java/de/fearnixx/jeak/reflect/RequestBody.java
@@ -10,12 +10,9 @@ import java.lang.annotation.Target;
  *
  * type(): REQUIRED Specify the class of the used variable.
  *
- * name(): REQUIRED Specify the name of the used variable.
- *
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
 public @interface RequestBody {
     Class<?> type();
-    String name();
 }

--- a/src/main/java/de/fearnixx/jeak/service/controller/testImpls/SecondTestController.java
+++ b/src/main/java/de/fearnixx/jeak/service/controller/testImpls/SecondTestController.java
@@ -20,7 +20,7 @@ public class SecondTestController {
     }
 
     @RequestMapping(method = RequestMethod.POST, endpoint = "/body")
-    public String sendBody(@RequestBody(type = String.class, name = "string") String string) {
+    public String sendBody(@RequestBody(type = String.class) String string) {
         return "second body " + string;
     }
 }

--- a/src/main/java/de/fearnixx/jeak/service/controller/testImpls/SecondTestController.java
+++ b/src/main/java/de/fearnixx/jeak/service/controller/testImpls/SecondTestController.java
@@ -20,7 +20,7 @@ public class SecondTestController {
     }
 
     @RequestMapping(method = RequestMethod.POST, endpoint = "/body")
-    public String sendBody(@RequestBody(type = String.class) String string) {
+    public String sendBody(@RequestBody() String string) {
         return "second body " + string;
     }
 }

--- a/src/main/java/de/fearnixx/jeak/service/controller/testImpls/TestController.java
+++ b/src/main/java/de/fearnixx/jeak/service/controller/testImpls/TestController.java
@@ -24,7 +24,7 @@ public class TestController {
     }
 
     @RequestMapping(method = RequestMethod.POST, endpoint = "/body")
-    public String sendBody(@RequestBody(type = String.class) String string) {
+    public String sendBody(@RequestBody() String string) {
         return "this is the body " + string;
     }
 

--- a/src/main/java/de/fearnixx/jeak/service/controller/testImpls/TestController.java
+++ b/src/main/java/de/fearnixx/jeak/service/controller/testImpls/TestController.java
@@ -24,7 +24,7 @@ public class TestController {
     }
 
     @RequestMapping(method = RequestMethod.POST, endpoint = "/body")
-    public String sendBody(@RequestBody(type = String.class, name = "string") String string) {
+    public String sendBody(@RequestBody(type = String.class) String string) {
         return "this is the body " + string;
     }
 


### PR DESCRIPTION
WARNING: this change is breaking for every controller which previously used the RequestBody annotation. 
Does anybody use it yet? If not, I think this breaking change would be ok. Otherwise I could also implement it non breaking.